### PR TITLE
fix: pydantic-ai-slim >=1.95 compatibility and release 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## `0.2.6` - May 28, 2026
+
+- Fix compatibility with `pydantic-ai-slim` >=1.95: replace removed `_get_instructions` with `_get_instruction_parts` ([#8](https://github.com/mochow13/pydantic-ai-litellm/issues/8)).
+- Merge consecutive leading system messages for strict LiteLLM/vLLM backends.
+- Dependencies: require `litellm>=1.86.2` and `pydantic-ai-slim>=1.95.0` (raised from `>=1.83.8` / `>=1.82.0` in `0.2.5`).
+
+**Notes for upgraders** (public `LiteLLMModel` / `LiteLLMModelSettings` API is unchanged):
+
+- **Dependency floors**: upgrading from `0.2.5` requires `pydantic-ai-slim` >=1.95 and `litellm` >=1.86.2; older pins will not resolve.
+- **Subclasses**: `_map_messages` now takes `model_request_parameters`; override it only with the updated signature.
+- **Instruction message ordering**: agent instructions are inserted before the first non-system message and consecutive leading system messages are merged with `\n\n` — a subtle behavior change vs always prepending a single system message at index 0.
+
 ## `0.2.5` - Apr 16, 2026
 
 - New upload on PyPI: `0.2.4` artifacts cannot be overwritten ([file name reuse](https://pypi.org/help/#file-name-reuse)), so this patch increments the version only for publishing.

--- a/examples/01_quick_start.py
+++ b/examples/01_quick_start.py
@@ -23,7 +23,7 @@ async def main():
     # Run inference
     result = await agent.run("What is the capital of France?")
     print(f"Result: {result.output}")
-    print(f"Usage: {result.usage()}")
+    print(f"Usage: {result.usage}")
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/02_custom_endpoints.py
+++ b/examples/02_custom_endpoints.py
@@ -24,7 +24,7 @@ async def main():
     try:
         result = await agent.run("Hello! Can you tell me about yourself?")
         print(f"Custom endpoint result: {result.output}")
-        print(f"Usage: {result.usage()}")
+        print(f"Usage: {result.usage}")
     except Exception as e:
         print(f"Error with custom endpoint: {e}")
         print("Note: This example requires a valid custom endpoint URL and API key")

--- a/examples/03_tool_calling.py
+++ b/examples/03_tool_calling.py
@@ -41,19 +41,19 @@ async def main():
         # Test weather tool
         result = await agent.run("What's the weather in Paris?")
         print(f"Weather query result: {result.output}")
-        print(f"Usage: {result.usage()}")
+        print(f"Usage: {result.usage}")
         print()
         
         # Test calculation tool
         result = await agent.run("What is 25 * 4 + 10?")
         print(f"Calculation result: {result.output}")
-        print(f"Usage: {result.usage()}")
+        print(f"Usage: {result.usage}")
         print()
         
         # Test multiple tools in one conversation
         result = await agent.run("Calculate 15 + 27 and then tell me the weather in Tokyo")
         print(f"Multi-tool result: {result.output}")
-        print(f"Usage: {result.usage()}")
+        print(f"Usage: {result.usage}")
         
     except Exception as e:
         print(f"Tool calling failed: {e}")

--- a/examples/05_structured_output.py
+++ b/examples/05_structured_output.py
@@ -43,7 +43,7 @@ async def main():
         print(f"Name: {person.name}")
         print(f"Age: {person.age}")
         print(f"Occupation: {person.occupation}")
-        print(f"Usage: {result.usage()}")
+        print(f"Usage: {result.usage}")
         print()
         
     except Exception as e:
@@ -71,7 +71,7 @@ async def main():
         print(f"Overall Score: {review.overall_score}/10")
         print(f"Strengths: {review.strengths}")
         print(f"Suggestions: {review.suggestions}")
-        print(f"Usage: {result.usage()}")
+        print(f"Usage: {result.usage}")
         print()
         
     except Exception as e:
@@ -92,7 +92,7 @@ async def main():
         print(f"Temperature: {weather.temperature}°C")
         print(f"Condition: {weather.condition}")
         print(f"Humidity: {weather.humidity}%")
-        print(f"Usage: {result.usage()}")
+        print(f"Usage: {result.usage}")
         
     except Exception as e:
         print(f"Weather generation failed: {e}")

--- a/examples/06_configuration.py
+++ b/examples/06_configuration.py
@@ -30,7 +30,7 @@ async def main():
     try:
         result = await agent.run("Write a short creative story in exactly 100 words")
         print(f"Result: {result.output}")
-        print(f"Usage: {result.usage()}")
+        print(f"Usage: {result.usage}")
         print()
         
     except Exception as e:
@@ -88,7 +88,7 @@ async def main():
         limited_agent = Agent(model=limited_model)
         result = await limited_agent.run("Explain quantum computing in detail")
         print(f"Limited tokens response: {result.output}")
-        print(f"Usage: {result.usage()}")
+        print(f"Usage: {result.usage}")
         
     except Exception as e:
         print(f"Token limit example failed: {e}")

--- a/examples/07_install_from_pypi.py
+++ b/examples/07_install_from_pypi.py
@@ -77,7 +77,7 @@ async def main() -> None:
         "What's going on with order ORD-1001A? One short sentence with the status."
     )
     print(result.output)
-    print(f"usage: {result.usage()}")
+    print(f"usage: {result.usage}")
 
 
 if __name__ == "__main__":

--- a/pydantic_ai_litellm/litellm_model.py
+++ b/pydantic_ai_litellm/litellm_model.py
@@ -42,6 +42,24 @@ __all__ = (
     'LiteLLMModelSettings',
 )
 
+
+def _merge_leading_system_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Merge consecutive leading system messages into one.
+
+    Required by strict OpenAI-compatible backends (some LiteLLM/vLLM deployments) that
+    reject more than one initial system message.
+    """
+    leading_count = next(
+        (i for i, m in enumerate(messages) if m.get('role') != 'system'),
+        len(messages),
+    )
+    if leading_count < 2:
+        return messages
+
+    merged_content = '\n\n'.join(m['content'] for m in messages[:leading_count])
+    merged = {**messages[0], 'content': merged_content}
+    return [merged, *messages[leading_count:]]
+
 class LiteLLMModelSettings(ModelSettings, total=False):
     """Settings used for a LiteLLM model request."""
 
@@ -160,7 +178,7 @@ class LiteLLMModel(Model):
             else:
                 tool_choice = 'auto'
 
-        litellm_messages = await self._map_messages(messages)
+        litellm_messages = await self._map_messages(messages, model_request_parameters)
 
         # Prepare completion arguments
         completion_kwargs: dict[str, Any] = {
@@ -316,7 +334,9 @@ class LiteLLMModel(Model):
             },
         }
 
-    async def _map_messages(self, messages: list[ModelMessage]) -> list[dict[str, Any]]:
+    async def _map_messages(
+        self, messages: list[ModelMessage], model_request_parameters: ModelRequestParameters
+    ) -> list[dict[str, Any]]:
         """Map pydantic_ai messages to LiteLLM format (OpenAI-compatible)."""
         litellm_messages: list[dict[str, Any]] = []
         
@@ -397,13 +417,17 @@ class LiteLLMModel(Model):
             else:
                 assert_never(message)
 
-        # Add instructions as system message if present
-        if instructions := self._get_instructions(messages):
-            # Insert at the beginning
-            litellm_messages.insert(0, {
-                'role': 'system',
-                'content': instructions,
-            })
+        if instruction_parts := self._get_instruction_parts(messages, model_request_parameters):
+            system_prompt_count = next(
+                (i for i, m in enumerate(litellm_messages) if m.get('role') != 'system'),
+                len(litellm_messages),
+            )
+            instruction_messages = [
+                {'role': 'system', 'content': part.content}
+                for part in instruction_parts
+            ]
+            litellm_messages[system_prompt_count:system_prompt_count] = instruction_messages
+            litellm_messages = _merge_leading_system_messages(litellm_messages)
 
         return litellm_messages
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-litellm"
-version = "0.2.5"
+version = "0.2.6"
 description = "LiteLLM model integration for Pydantic AI framework - access 100+ LLM providers through a unified interface"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -25,8 +25,8 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "litellm>=1.83.8",
-    "pydantic-ai-slim>=1.82.0",
+    "litellm>=1.86.2",
+    "pydantic-ai-slim>=1.95.0",
 ]
 
 [project.urls]

--- a/tests/integration_tests/test_litellm_integration.py
+++ b/tests/integration_tests/test_litellm_integration.py
@@ -30,7 +30,7 @@ async def test_basic_completion():
         
         result = await agent.run("What is 2+2? Answer with just the number.")
         print(f"Result: {result.output}")
-        print(f"Usage: {result.usage()}")
+        print(f"Usage: {result.usage}")
         
     except Exception as e:
         print(f"Failed to test {model.model_name}: {str(e)}")
@@ -127,7 +127,7 @@ async def test_tool_calling():
         result = await agent.run("What is 2129731231494*208977523231?")
 
         print(f"Result: {result.output}")
-        print(f"Usage: {result.usage()}")
+        print(f"Usage: {result.usage}")
         print(f"Messages: {result.all_messages()}")
         print(f"Test tool calling completed.")
 

--- a/tests/unit_tests/test_map_messages.py
+++ b/tests/unit_tests/test_map_messages.py
@@ -1,0 +1,78 @@
+"""Tests for LiteLLMModel message mapping and instruction handling."""
+
+import pytest
+
+from pydantic_ai.messages import (
+    InstructionPart,
+    ModelRequest,
+    SystemPromptPart,
+    UserPromptPart,
+)
+from pydantic_ai.models import ModelRequestParameters
+
+from pydantic_ai_litellm import LiteLLMModel
+
+
+class TestMapMessages:
+    """Tests for _map_messages instruction handling."""
+
+    def setup_method(self):
+        self.model = LiteLLMModel(model_name="gpt-4", api_key="test-key")
+
+    @pytest.mark.asyncio
+    async def test_instruction_parts_inserted_before_user(self):
+        """Instruction parts are inserted before the first non-system message."""
+        messages = [ModelRequest([UserPromptPart("Hello")])]
+        params = ModelRequestParameters(
+            function_tools=[],
+            output_tools=[],
+            allow_text_output=True,
+            instruction_parts=[InstructionPart(content="Be helpful.")],
+        )
+
+        result = await self.model._map_messages(messages, params)
+
+        assert len(result) == 2
+        assert result[0] == {'role': 'system', 'content': 'Be helpful.'}
+        assert result[1] == {'role': 'user', 'content': 'Hello'}
+
+    @pytest.mark.asyncio
+    async def test_multiple_instruction_parts_merged_with_system_prompt(self):
+        """Multiple instruction parts and SystemPromptPart merge into one system message."""
+        messages = [
+            ModelRequest([
+                SystemPromptPart("Base prompt."),
+                UserPromptPart("Hello"),
+            ])
+        ]
+        params = ModelRequestParameters(
+            function_tools=[],
+            output_tools=[],
+            allow_text_output=True,
+            instruction_parts=[
+                InstructionPart(content="Instruction A."),
+                InstructionPart(content="Instruction B."),
+            ],
+        )
+
+        result = await self.model._map_messages(messages, params)
+
+        assert len(result) == 2
+        assert result[0]['role'] == 'system'
+        assert result[0]['content'] == 'Base prompt.\n\nInstruction A.\n\nInstruction B.'
+        assert result[1] == {'role': 'user', 'content': 'Hello'}
+
+    @pytest.mark.asyncio
+    async def test_no_instruction_parts(self):
+        """No extra system message when instruction parts are absent."""
+        messages = [ModelRequest([UserPromptPart("Hello")])]
+        params = ModelRequestParameters(
+            function_tools=[],
+            output_tools=[],
+            allow_text_output=True,
+        )
+
+        result = await self.model._map_messages(messages, params)
+
+        assert len(result) == 1
+        assert result[0] == {'role': 'user', 'content': 'Hello'}

--- a/uv.lock
+++ b/uv.lock
@@ -857,7 +857,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.8"
+version = "1.86.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -873,9 +873,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/5a/a7b4b4bf9443b1f1d8fb1e1ed7d1936eca93851ff3e43113c3dad17c6556/litellm-1.83.8.tar.gz", hash = "sha256:38db022b4bf5a51cbe597a8308e6e51eb71254ae684d41aa210b76df0c827063", size = 14751978, upload-time = "2026-04-15T03:37:51.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/1f6f3f5d01e0910629b6af3757e82c47b8b87dca497a661a9c63280b4bd8/litellm-1.86.2.tar.gz", hash = "sha256:7d559ad48b97d796ff325af88fd7eebbdc66e58773fb5312130ab1cac968f8f3", size = 15380548, upload-time = "2026-05-27T16:19:58.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/02/ee86522b2cb359079596d224db9b23dc12c02d7eeaf3d458abd7a0c54444/litellm-1.83.8-py3-none-any.whl", hash = "sha256:3bc8cfeff9d73a6a11409006c0d66bafeed9a23db65f642000f72f1cdb2e9ce8", size = 16333221, upload-time = "2026-04-15T03:37:47.934Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/37/4da1dd67157aaa11477d6c63e4725216bfc46b4661e581b490d17e5b2831/litellm-1.86.2-py3-none-any.whl", hash = "sha256:27096463be7add661513ada3d9039e8f1a6195859e604d30fde96c939efe0a03", size = 17013061, upload-time = "2026-05-27T16:19:53.219Z" },
 ]
 
 [[package]]
@@ -1312,7 +1312,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-litellm"
-version = "0.2.5"
+version = "0.2.6"
 source = { virtual = "." }
 dependencies = [
     { name = "litellm" },
@@ -1328,8 +1328,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "litellm", specifier = ">=1.83.8" },
-    { name = "pydantic-ai-slim", specifier = ">=1.82.0" },
+    { name = "litellm", specifier = ">=1.86.2" },
+    { name = "pydantic-ai-slim", specifier = ">=1.95.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1341,7 +1341,7 @@ dev = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.82.0"
+version = "1.103.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -1353,9 +1353,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/33/6b75ea6d59575b8dcce01922666b3152afbf76e2b606992e1c87bfa49172/pydantic_ai_slim-1.82.0.tar.gz", hash = "sha256:8f0f0eac4d3102e576fb9655d36d9f4efc1a599d81e8fe62d37652ef1e6a3913", size = 551393, upload-time = "2026-04-15T02:51:55.528Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/ce/ae3cd88af67e418e8d68749b1014d52aa84188acee438241ec819918a31a/pydantic_ai_slim-1.103.0.tar.gz", hash = "sha256:b0fda8eea125440b74c1de9cb5c8ed4fa6cfae72586b7de03581adf263903b8a", size = 748460, upload-time = "2026-05-27T02:49:04.141Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/68/c1f572e50c2b5a6dbd121866d17f53df7b2f451de46159cf46498de73b84/pydantic_ai_slim-1.82.0-py3-none-any.whl", hash = "sha256:22fcaae5bfb6a024f3dcf28c8e3859adc23a7cae4be9f49873cf7f5da8bf78dd", size = 705400, upload-time = "2026-04-15T02:51:47.975Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/36/261c0891cc0925a59f0f3741ef2057ff3074c9a7940220ea39f83e9dd434/pydantic_ai_slim-1.103.0-py3-none-any.whl", hash = "sha256:866d5a6376f113bcb7e20749b87640db919efd9a44fdbb73574b77f06bc83c3d", size = 927993, upload-time = "2026-05-27T02:48:56.067Z" },
 ]
 
 [[package]]
@@ -1478,7 +1478,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.82.0"
+version = "1.103.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1486,9 +1486,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/6d/507d5344f91d437d9eac8320b38106d4885d360660e112828a95ab17fed4/pydantic_graph-1.82.0.tar.gz", hash = "sha256:78facea28c206ce9b459ae18344db4af0ded5bd4b3e08eb4458b8298453979e2", size = 59243, upload-time = "2026-04-15T02:51:57.958Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/f9/301c8477cc2309d827ef0e99e73c36581bd9d8811bd85a2a8bdd58a17a74/pydantic_graph-1.103.0.tar.gz", hash = "sha256:174ce80e3a67e393a227c70f5c9531497a15ce064fae8aef4635c1a5d9507c68", size = 62589, upload-time = "2026-05-27T02:49:06.61Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/3f/4215971d86c6ae662edad5d4dc07a14ec16f8385e7231862599777672fab/pydantic_graph-1.82.0-py3-none-any.whl", hash = "sha256:db7ebc4de07236795c9c2f429404a387cf47ec44afc033e39c9cda26e937cff0", size = 73066, upload-time = "2026-04-15T02:51:51.235Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fb/60037718a0219933ae4fd2c393c69529260593a49f3fd334b3e7f9e3a912/pydantic_graph-1.103.0-py3-none-any.whl", hash = "sha256:98687e53811db9e324fabbf5f4692b5dd6af458591461ab6255230d8bc4bebf3", size = 80100, upload-time = "2026-05-27T02:48:59.756Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Replace removed _get_instructions with _get_instruction_parts
- Merge consecutive leading system messages for strict LiteLLM/vLLM backends
- Raise dependency floors
- Update examples to use result.usage.