### PR TITLE
fix: remove double-counting of RunUsage.requests in non-streamed requests

### DIFF
--- a/pydantic_ai_litellm/litellm_model.py
+++ b/pydantic_ai_litellm/litellm_model.py
@@ -134,9 +134,7 @@ class LiteLLMModel(Model):
         response = await self._completion_create(
             messages, False, cast(LiteLLMModelSettings, model_settings or {}), model_request_parameters
         )
-        model_response = self._process_response(response)
-        model_response.usage.requests = 1
-        return model_response
+        return self._process_response(response)
 
     @asynccontextmanager
     async def request_stream(

--- a/tests/unit_tests/test_tool_calling.py
+++ b/tests/unit_tests/test_tool_calling.py
@@ -198,6 +198,12 @@ class TestToolCalling:
             output_tools=[],
             allow_text_output=True
         )
-        
+
         tools = self.model._get_tools(model_params)
         assert tools == []
+
+    def test_process_response_does_not_set_requests(self):
+        """_process_response must not set requests — the pydantic-ai framework counts it."""
+        mock_response = MockLiteLLMResponse(content="Hello")
+        result = self.model._process_response(mock_response)
+        assert result.usage.requests == 0


### PR DESCRIPTION
`pydantic-ai's _agent_graph.py` already increments requests after every model call; explicitly setting `requests=1` on the returned ModelResponse caused it to be added again via `usage.incr()`, producing `requests=2`.

Closes #10